### PR TITLE
simplify curator screen due to atomic auction house removal

### DIFF
--- a/apps/dapp/src/modules/auction/curatable-auction-list.tsx
+++ b/apps/dapp/src/modules/auction/curatable-auction-list.tsx
@@ -113,7 +113,9 @@ function CurateButton(
   props: React.HTMLAttributes<HTMLButtonElement> & { approved?: boolean },
 ) {
   return !props.approved ? (
-    <Button {...props}>Curate</Button>
+    <Button size="sm" {...props}>
+      Curate
+    </Button>
   ) : (
     <Tooltip content="You've accepted curating this auction">
       <CheckIcon className="text-axis-green" />

--- a/apps/dapp/src/modules/auction/curator-fee-manager.tsx
+++ b/apps/dapp/src/modules/auction/curator-fee-manager.tsx
@@ -44,9 +44,9 @@ export function CuratorFeeManager({
         >
           <InfoLabel
             editable
-            label={"Batch Auctions"}
+            label={"Current Fee"}
             value={fee || curatorFees.fee + "%"}
-            inputClassName="w-24 min-w-0 pl-0"
+            inputClassName="w-16 min-w-0 pl-0"
             onChange={(e) => {
               parsePercent(e);
               setFee(e.target.value);

--- a/apps/dapp/src/pages/curator-page.tsx
+++ b/apps/dapp/src/pages/curator-page.tsx
@@ -22,11 +22,11 @@ export function CuratorPage() {
 
   return (
     <PageContainer title="Curator">
-      <div className="flex ">
+      <div className="flex gap-x-4 px-4">
         <Card
           title={
             <div className="gap-x-4">
-              <Tooltip content="Fees are set per chain and auction house. Click percentage field below to edit your fee and the checkmark to submit the transaction.">
+              <Tooltip content="Click percentage field below to edit your fee and the checkmark to submit the transaction.">
                 <CardTitle className="flex items-center gap-x-2">
                   Fees <InfoIcon className="size-4" />
                 </CardTitle>
@@ -44,10 +44,6 @@ export function CuratorPage() {
             <CuratorFeeManager
               modules={[AuctionType.FIXED_PRICE_BATCH]}
               auctionType={AuctionType.FIXED_PRICE_BATCH}
-            />
-            <CuratorFeeManager
-              modules={[AuctionType.SEALED_BID]}
-              auctionType={AuctionType.SEALED_BID}
             />
           </div>
         </Card>


### PR DESCRIPTION
Was still showing a fee adjuster for the atomic AH, removed:

![curator-interace](https://github.com/Axis-Fi/fireworks/assets/52055541/8dfc1657-aaf5-4859-bc67-a670f3de069c)


Probably could use a redesign but I think it'll do for now