### PR TITLE
allow navigating to the curator page without being a curator

### DIFF
--- a/apps/dapp/src/pages/curator-page.tsx
+++ b/apps/dapp/src/pages/curator-page.tsx
@@ -5,20 +5,17 @@ import { InfoIcon } from "lucide-react";
 import { PageContainer } from "modules/app/page-container";
 import { CuratableAuctionList } from "modules/auction/curatable-auction-list";
 import { CuratorFeeManager } from "modules/auction/curator-fee-manager";
-import { useCurator } from "modules/auction/hooks/use-curator";
 import { useChainId, useSwitchChain } from "wagmi";
 
 export function CuratorPage() {
   const chainId = useChainId();
-  const { isCurator } = useCurator();
   const { switchChain } = useSwitchChain();
+
   const options = activeChains.map((c) => ({
     label: c.name,
     imgURL: c.iconUrl as string,
     value: c.id.toString(),
   }));
-
-  if (!isCurator) return null;
 
   return (
     <PageContainer title="Curator">


### PR DESCRIPTION
The curator fee has to be set prior to an Address being appointed as curator (before auction creation).

This change allows users to access the curator page in to set the fee before being appointed. 
Navlink will remain unchanged, only showing after the user has been appointed. 