### PR TITLE
Updated Uniswap V2 DTL callbacks

### DIFF
--- a/packages/deployments/chains/testnet/arbitrum-sepolia.ts
+++ b/packages/deployments/chains/testnet/arbitrum-sepolia.ts
@@ -19,7 +19,7 @@ const config: AxisDeploymentConfig = {
     merkleAllowlist: "0x9837cA34C444cEbd07C699036D1D174C6392D9fa",
     tokenAllowlist: "0x988c61b36F7898e464a0Bf477d2dc06aC4E95F95",
     allocatedMerkleAllowlist: "0x98B59b4BF62b0316D9B0f89D28A28d5D75BB8B46",
-    uniV2Dtl: "0xE64E0807E5a0d789dB2fABB3345aB763f879521C",
+    uniV2Dtl: "0xE676907Fa9a09dC1E3b67De11816665A1313524f",
     uniV3Dtl: "0xE6ECF0f655E642834c79F30323e7ae941883ac00",
   },
   subgraphURL:

--- a/packages/deployments/chains/testnet/base-sepolia.ts
+++ b/packages/deployments/chains/testnet/base-sepolia.ts
@@ -18,7 +18,7 @@ const config: AxisDeploymentConfig = {
     merkleAllowlist: "0x9837cA34C444cEbd07C699036D1D174C6392D9fa",
     tokenAllowlist: "0x988c61b36F7898e464a0Bf477d2dc06aC4E95F95",
     allocatedMerkleAllowlist: "0x98B59b4BF62b0316D9B0f89D28A28d5D75BB8B46",
-    uniV2Dtl: "0xE650A43485b89F26FB98ad16811BF45BD52ad014",
+    uniV2Dtl: "0xE66538D4EEbf830b1Dc791894af4709Af257764d",
     uniV3Dtl: "0xE661c46d94c53584095A8240958695bAD6d6fC2F",
   },
   subgraphURL:

--- a/packages/deployments/chains/testnet/blast-sepolia.ts
+++ b/packages/deployments/chains/testnet/blast-sepolia.ts
@@ -18,7 +18,7 @@ const config: AxisDeploymentConfig = {
     merkleAllowlist: "0x9859c6FA2594e93149bd76415cE3982f39888CCb",
     tokenAllowlist: "0x984B6165fC87c682441E81B4aa23A017cdbFba18",
     allocatedMerkleAllowlist: "0x986455Ab4f64303E8F51e72F6BF1789182563F65",
-    uniV2Dtl: "0xE6282DDB61f81F4d769FE511676dC21E570AF815",
+    uniV2Dtl: "0xE60007A0721A92f0eb538c360317d4808238700D",
     uniV3Dtl: "0xE6b1113d108f86Fb7eF662ecF235dB6dB8978Cc3",
   },
   subgraphURL:

--- a/packages/deployments/chains/testnet/mode-testnet.ts
+++ b/packages/deployments/chains/testnet/mode-testnet.ts
@@ -18,7 +18,7 @@ const config: AxisDeploymentConfig = {
     merkleAllowlist: "0x9837cA34C444cEbd07C699036D1D174C6392D9fa",
     tokenAllowlist: "0x988c61b36F7898e464a0Bf477d2dc06aC4E95F95",
     allocatedMerkleAllowlist: "0x98B59b4BF62b0316D9B0f89D28A28d5D75BB8B46",
-    uniV2Dtl: "0xE60f928d399782836540752Eb3fCfE46b0Cb4E24",
+    uniV2Dtl: "0xE60FD6203AF5D5d43433952a033Cb70Ba21784E9",
     uniV3Dtl: "0xE6ce65C413a5Fc10Fa77B26032B33DCD68F8474a",
   },
   subgraphURL:


### PR DESCRIPTION
There was an issue with the Uniswap V2 router that we had deployed, which the Uniswap V2 DTL is bound to. Both the Uniswap V2 router and the DTL have been re-deployed on all testnet chains.