### PR TITLE
chore: disable goldsky temporarily

### DIFF
--- a/packages/deployments/chains/testnet/index.ts
+++ b/packages/deployments/chains/testnet/index.ts
@@ -1,6 +1,8 @@
-import blastSepolia from "./blast-sepolia";
+// TODO: re-enable blast/mode (Goldsky deployments) once we've resolved the Goldsky issues or moved provider
+// import blastSepolia from "./blast-sepolia";
 import arbitrumSepolia from "./arbitrum-sepolia";
-import modeTestnet from "./mode-testnet";
+// import modeTestnet from "./mode-testnet";
 import baseSepolia from "./base-sepolia";
 
-export default [blastSepolia, arbitrumSepolia, modeTestnet, baseSepolia];
+// export default [blastSepolia, arbitrumSepolia, modeTestnet, baseSepolia];
+export default [arbitrumSepolia, baseSepolia];


### PR DESCRIPTION
Goldsky is flaky - we'll hide it for testnet v3 deployment.