### PR TITLE
fix: amend launch token cta text

### DIFF
--- a/apps/dapp/src/pages/auction-list-page.tsx
+++ b/apps/dapp/src/pages/auction-list-page.tsx
@@ -258,10 +258,10 @@ export default function AuctionListPage() {
 
           {!environment.isProduction && (
             <div className="flex flex-col items-center justify-center py-8">
-              <p className="pb-2 font-sans">Want to create an auction?</p>
+              <p className="pb-2 font-sans">Want to launch your token?</p>
               <Link to="/create/auction">
                 <Button variant="ghost">
-                  Create Auction <ArrowRightIcon className="w-6 pl-1" />
+                  Launch token <ArrowRightIcon className="w-6 pl-1" />
                 </Button>
               </Link>
             </div>


### PR DESCRIPTION
Was missed in the terminology change: auction -> launch