### PR TITLE
fix: invalid html in dapp

### DIFF
--- a/apps/dapp/src/components/reload-button.tsx
+++ b/apps/dapp/src/components/reload-button.tsx
@@ -12,7 +12,7 @@ export function ReloadButton({
   ...rest
 }: ReloadButtonProps) {
   return (
-    <Tooltip content={tooltip}>
+    <Tooltip content={tooltip} asChild>
       <Button {...rest} size="icon" variant="ghost">
         <RefreshCwIcon className={cn(refetching && "loading-indicator-fast")} />
       </Button>

--- a/apps/dapp/src/modules/app/page-header.tsx
+++ b/apps/dapp/src/modules/app/page-header.tsx
@@ -7,26 +7,29 @@ type PageHeaderProps = React.HTMLAttributes<HTMLDivElement> & {
   backNavigationText?: string;
 };
 
-export function PageHeader(props: PageHeaderProps) {
+export function PageHeader({
+  className,
+  backNavigationPath,
+  backNavigationText = "Back to Launches",
+  children,
+}: PageHeaderProps) {
   const navigate = useNavigate();
   return (
-    <div
-      className={cn("max-w-limit mt-5 flex justify-between", props.className)}
-    >
+    <div className={cn("max-w-limit mt-5 flex justify-between", className)}>
       <Button
         className="w-fit"
         size="icon"
         variant="ghost"
         //@ts-expect-error interesting TS quirk below,
         //both string and number are valid but on different signatures
-        onClick={() => navigate(props.backNavigationPath ?? -1)}
+        onClick={() => navigate(backNavigationPath ?? -1)}
       >
         <div className="flex ">
           <ArrowLeft className="" />
-          Back to Launches
+          {backNavigationText}
         </div>
       </Button>
-      {props.children}
+      {children}
     </div>
   );
 }

--- a/apps/dapp/src/modules/app/reach-out.tsx
+++ b/apps/dapp/src/modules/app/reach-out.tsx
@@ -9,14 +9,12 @@ export function ReachOutMessage({
 }: React.HTMLAttributes<HTMLParagraphElement>) {
   return (
     <div className={cn("flex gap-x-1", className)} {...props}>
-      <p>
-        {children ?? "If the problem persists reach us out in "}
-        <Link className="inline text-[#7289da]" href={metadata.discord}>
-          <div className="inline-flex items-center gap-x-1">
-            <p className="font-bold">Discord</p>
-          </div>
-        </Link>
-      </p>
+      {children ?? "If the problem persists reach us out in "}
+      <Link className="inline text-[#7289da]" href={metadata.discord}>
+        <div className="inline-flex items-center gap-x-1">
+          <span className="font-bold">Discord</span>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/apps/dapp/src/modules/auction/referrer-popover.tsx
+++ b/apps/dapp/src/modules/auction/referrer-popover.tsx
@@ -38,7 +38,7 @@ export function ReferrerPopover({ auction }: PropsWithAuction) {
 
   return (
     <Popover>
-      <PopoverTrigger>
+      <PopoverTrigger asChild>
         <Button variant="secondary" size="sm">
           Refer this launch
         </Button>

--- a/apps/dapp/src/modules/token/token-amount-input.tsx
+++ b/apps/dapp/src/modules/token/token-amount-input.tsx
@@ -1,4 +1,5 @@
 import { Input, Text, Button, cn } from "@repo/ui";
+import React from "react";
 
 type TokenAmountInputProps = React.HTMLAttributes<HTMLInputElement> & {
   /** the input's label */
@@ -25,91 +26,102 @@ type TokenAmountInputProps = React.HTMLAttributes<HTMLInputElement> & {
   onClickMaxButton?: () => void;
 };
 
-export function TokenAmountInput({
-  label,
-  symbol,
-  usdPrice,
-  balance,
-  limit,
-  error,
-  message,
-  value,
-  disabled,
-  disableMaxButton,
-  onClickMaxButton,
-  ...props
-}: TokenAmountInputProps) {
-  return (
-    <div
-      className={cn(
-        "hover:bg-surface-secondary bg-surface-tertiary group rounded border-2 border-transparent p-4 transition-all",
-        error && "border-feedback-alert",
-        disabled && "opacity-50",
-      )}
-    >
-      <div className="flex">
-        <div className="flex-start">
-          <Text color="secondary">{label}</Text>
+export const TokenAmountInput = React.forwardRef<
+  HTMLInputElement,
+  TokenAmountInputProps
+>(
+  (
+    {
+      label,
+      symbol,
+      usdPrice,
+      balance,
+      limit,
+      error,
+      message,
+      value,
+      disabled,
+      disableMaxButton,
+      onClickMaxButton,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <div
+        className={cn(
+          "hover:bg-surface-secondary bg-surface-tertiary group rounded border-2 border-transparent p-4 transition-all",
+          error && "border-feedback-alert",
+          disabled && "opacity-50",
+        )}
+      >
+        <div className="flex">
+          <div className="flex-start">
+            <Text color="secondary">{label}</Text>
+          </div>
         </div>
-      </div>
-      <div className="mt-0.5 flex items-center">
-        <Input
-          {...props}
-          value={value}
-          type="number"
-          variant="lg"
-          disabled={disabled}
-          placeholder="0"
-          className={cn(
-            "hover:bg-surface-secondary ml-0 pl-0",
-            error && "text-feedback-alert",
-          )}
-        />
-        <Text className="text-nowrap" color="secondary" size="lg">
-          {symbol}{" "}
-        </Text>
-        {!disableMaxButton && (
-          <Button
+        <div className="mt-0.5 flex items-center">
+          <Input
+            {...props}
+            value={value}
+            ref={ref}
+            type="number"
+            variant="lg"
             disabled={disabled}
-            uppercase
-            variant="secondary"
-            size="sm"
-            className="ml-1 h-min rounded-full px-1.5 py-1 leading-none"
-            onClick={() => {
-              onClickMaxButton?.();
-            }}
-          >
-            Max
-          </Button>
-        )}
-      </div>
-      <div className="flex justify-between">
-        {usdPrice && (
-          <div className="flex items-start">
-            <Text size="xs" color="secondary">
-              ≈{usdPrice}
-            </Text>
-          </div>
-        )}
-        {balance && (
-          <div className="ml-auto flex items-end">
-            <Text size="xs" color="secondary" uppercase>
-              Balance: {balance} {limit ? `Limit: ${limit}` : ""}
-            </Text>
-          </div>
-        )}
-      </div>
-      {error && (
-        <div className="bg-feedback-alert mt-1.5 rounded p-2">
-          <Text color="tertiary">{error}</Text>
+            placeholder="0"
+            className={cn(
+              "hover:bg-surface-secondary ml-0 pl-0",
+              error && "text-feedback-alert",
+            )}
+          />
+          <Text className="text-nowrap" color="secondary" size="lg">
+            {symbol}{" "}
+          </Text>
+          {!disableMaxButton && (
+            <Button
+              disabled={disabled}
+              uppercase
+              variant="secondary"
+              size="sm"
+              className="ml-1 h-min rounded-full px-1.5 py-1 leading-none"
+              onClick={() => {
+                onClickMaxButton?.();
+              }}
+            >
+              Max
+            </Button>
+          )}
         </div>
-      )}
+        <div className="flex justify-between">
+          {usdPrice && (
+            <div className="flex items-start">
+              <Text size="xs" color="secondary">
+                ≈{usdPrice}
+              </Text>
+            </div>
+          )}
+          {balance && (
+            <div className="ml-auto flex items-end">
+              <Text size="xs" color="secondary" uppercase>
+                Balance: {balance} {limit ? `Limit: ${limit}` : ""}
+              </Text>
+            </div>
+          )}
+        </div>
+        {error && (
+          <div className="bg-feedback-alert mt-1.5 rounded p-2">
+            <Text color="tertiary">{error}</Text>
+          </div>
+        )}
 
-      {message && (
-        <div className="mt-1.5 rounded border border-neutral-500 p-2">
-          <Text color="secondary">{message}</Text>
-        </div>
-      )}
-    </div>
-  );
-}
+        {message && (
+          <div className="mt-1.5 rounded border border-neutral-500 p-2">
+            <Text color="secondary">{message}</Text>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+TokenAmountInput.displayName = "TokenAmountInput";

--- a/apps/dapp/src/pages/auction-list-page.tsx
+++ b/apps/dapp/src/pages/auction-list-page.tsx
@@ -258,12 +258,12 @@ export default function AuctionListPage() {
 
           {!environment.isProduction && (
             <div className="flex flex-col items-center justify-center py-8">
-              <p className="pb-2 font-sans">Want to launch your token?</p>
-              <Link to="/create/auction">
-                <Button variant="ghost">
+              <p className="pb-2 font-sans">Want to launch a token?</p>
+              <Button variant="ghost" asChild>
+                <Link to="/create/auction">
                   Launch token <ArrowRightIcon className="w-6 pl-1" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </div>
           )}
         </PageContainer>

--- a/apps/dapp/src/pages/error-page.tsx
+++ b/apps/dapp/src/pages/error-page.tsx
@@ -26,11 +26,9 @@ export default function ErrorPage() {
             <ReachOutMessage />
           </>
         )}
-        <Link to="/">
-          <Button className="mt-4" variant="secondary" size="sm">
-            Head back
-          </Button>
-        </Link>
+        <Button className="mt-4" variant="secondary" size="sm">
+          <Link to="/">Head back</Link>
+        </Button>
       </div>
     </div>
   );

--- a/packages/ui/src/components/primitives/button/button.tsx
+++ b/packages/ui/src/components/primitives/button/button.tsx
@@ -13,14 +13,14 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, uppercase, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <>
         <Comp
           className={cn(
             buttonVariants({ variant, size, className }),
-            props.uppercase && "uppercase",
+            uppercase && "uppercase",
           )}
           ref={ref}
           {...props}

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -5,12 +5,16 @@ export function Tooltip(
   props: React.PropsWithChildren<{
     content: React.ReactNode;
     triggerClassName?: string;
+    asChild?: boolean;
   }>,
 ) {
   if (!props.content) return <>{props.children}</>;
   return (
     <TooltipRoot>
-      <TooltipTrigger className={cn("cursor-help", props.triggerClassName)}>
+      <TooltipTrigger
+        className={cn("cursor-help", props.triggerClassName)}
+        asChild={!!props.asChild}
+      >
         {props.children}
       </TooltipTrigger>
       <TooltipContent className="max-w-xs">


### PR DESCRIPTION
- the dapp is nesting certain html elements together which violate html schema rules
- this leads to a bunch of warnings being printed to the console
- this PR fixes every warning I could find, so there are no more console warnings polluting the console