### PR TITLE
update number format component

### DIFF
--- a/apps/dapp/src/modules/token/format.tsx
+++ b/apps/dapp/src/modules/token/format.tsx
@@ -26,8 +26,16 @@ export function Format(props: { value: string | number }) {
         return (
           <Tooltip content={valueString}>
             <span>
-              {integerPart}.0<sub>{trailingZeros}</sub>
-              {trimmedDecimal}
+              {trailingZeros > 2 ? (
+                <>
+                  {integerPart}.0<sub>{trailingZeros}</sub>
+                  {trimmedDecimal}{" "}
+                </>
+              ) : (
+                <>
+                  {integerPart}.{decimalPart.substring(0, trailingZeros + 3)}
+                </>
+              )}
             </span>
           </Tooltip>
         );


### PR DESCRIPTION
Format was only accounting for large numbers but in case the decimal trailling zeros are less than 3, we can show the regular trimmed number.

![Screenshot 2024-08-12 at 13 52 01](https://github.com/user-attachments/assets/7f1cb60e-6e20-4aa3-b97c-14b565c9cf80)
![Screenshot 2024-08-12 at 13 52 06](https://github.com/user-attachments/assets/f432cd8d-79bc-47f5-8a19-5c2eced5db1a)

