### PR TITLE
fix: remove leading slash from launch path

### DIFF
--- a/apps/dapp/src/modules/auction/curatable-auction-list.tsx
+++ b/apps/dapp/src/modules/auction/curatable-auction-list.tsx
@@ -89,7 +89,7 @@ export function CuratableAuctionList() {
       col.display({
         id: "view",
         cell: (info) => (
-          <Link to={"/" + getAuctionPath(info.row.original)}>
+          <Link to={getAuctionPath(info.row.original)}>
             <Button size="sm">View</Button>
           </Link>
         ),


### PR DESCRIPTION
- the view button link was accidentally generating an IP address path from the chainId, instead of a relative link path