### PR TITLE
fix: handle auction id of 0 instead of treating it as a falsy value

### DIFF
--- a/apps/dapp/src/modules/auction/auction-creation-status.tsx
+++ b/apps/dapp/src/modules/auction/auction-creation-status.tsx
@@ -17,6 +17,7 @@ import { CreateAuctionForm } from "pages/create-auction-page";
 import { Address, BaseError } from "viem";
 import { TransactionErrorDialog } from "modules/transaction/transaction-error-dialog";
 import { AuctionType } from "@repo/types";
+import { isNullOrUndefined } from "utils";
 
 type CreateAuctionStatusCardProps = {
   auctionHouseApproveTx: UseWriteContractReturnType;
@@ -242,13 +243,17 @@ export function AuctionCreationStatus({
       </div>
       {txReceipt.isSuccess && (
         <div className="flex justify-center">
-          <Tooltip content={!props.lotId ? "Waiting to get Auction Id..." : ""}>
+          <Tooltip
+            content={
+              isNullOrUndefined(props.lotId) ? "Waiting for Auction Id..." : ""
+            }
+          >
             <Button
-              disabled={!props.lotId}
+              disabled={isNullOrUndefined(props.lotId)}
               onClick={() => props.onSuccess()}
               className="mt-3"
             >
-              View your Auction
+              View your Launch
             </Button>
           </Tooltip>
         </div>

--- a/apps/dapp/src/utils/number.ts
+++ b/apps/dapp/src/utils/number.ts
@@ -66,3 +66,9 @@ export const shorten = (num: number, ignoreLessThan: number = 0): string => {
   if (mag < 1) return trimCurrency(num);
   return `${shortNum}${symbols[mag]}`;
 };
+
+export const isNullOrUndefined = (
+  value: unknown,
+): value is null | undefined => {
+  return value === null || value === undefined;
+};


### PR DESCRIPTION
-moving away from `!` shortcut to explicit null and undefined checks because `!` doesn't work for falsy values (like number 0)

e.g. `0 == false` -> `!0 == true` meaning the logic would think a lot ID of 0 is not defined, when it is.