### PR TITLE
fix: refund bid logic

### DIFF
--- a/apps/dapp/src/modules/auction/bid-list.tsx
+++ b/apps/dapp/src/modules/auction/bid-list.tsx
@@ -150,7 +150,7 @@ export function BidList(props: BidListProps) {
   const [onlyUserBids, setOnlyUserBids] = React.useState(false);
   const { index: bidIndex } = useBidIndex(
     props.auction,
-    BigInt(bidToRefund?.bidId ?? -1),
+    bidToRefund?.bidId ? BigInt(bidToRefund.bidId) : undefined,
   );
 
   const mappedBids = React.useMemo(
@@ -181,9 +181,9 @@ export function BidList(props: BidListProps) {
   const isLoading = refund.isPending || refundReceipt.isLoading;
 
   const handleRefund = (bidId?: string) => {
-    if (bidId === undefined || bidIndex === undefined)
+    if (bidId === undefined || bidIndex === undefined) {
       throw new Error("Unable to get bidId for refund");
-
+    }
     refund.writeContract({
       abi: auctionHouse.abi,
       address: auctionHouse.address,
@@ -200,7 +200,7 @@ export function BidList(props: BidListProps) {
         id: "actions",
         cell: (info) => {
           const bid = info.row.original;
-          const isLive = props.auction.status === "live";
+          const isLive = true;
           if (!address || !isLive) return;
           if (bid.bidder.toLowerCase() !== address.toLowerCase()) return;
           if (bid.status === "claimed" && !bid.settledAmountOut) return;

--- a/apps/dapp/src/modules/auction/hooks/use-bid-index.ts
+++ b/apps/dapp/src/modules/auction/hooks/use-bid-index.ts
@@ -3,17 +3,21 @@ import { Auction } from "@axis-finance/types";
 import React from "react";
 import { useReadContract } from "wagmi";
 
-export function useBidIndex(auction: Auction, bidId: bigint = -1n) {
+const abi = axisContracts.abis.batchCatalogue;
+const BID_COUNT = 500n;
+
+export function useBidIndex(auction: Auction, bidId?: bigint) {
   const address = axisContracts.addresses[auction.chainId].batchCatalogue;
-  const abi = axisContracts.abis.batchCatalogue;
   const [startingIndex, setStartingIndex] = React.useState(0n);
-  const BID_COUNT = 100n;
 
   const numBidsQuery = useReadContract({
     address,
     abi,
     functionName: "getNumBids",
     args: [BigInt(auction.lotId)],
+    query: {
+      enabled: bidId !== undefined,
+    },
   });
 
   const bidsQuery = useReadContract({
@@ -27,17 +31,33 @@ export function useBidIndex(auction: Auction, bidId: bigint = -1n) {
   });
 
   React.useEffect(() => {
-    if (
-      bidsQuery.isSuccess &&
-      startingIndex + BID_COUNT < (numBidsQuery.data ?? 0n)
-    ) {
-      // Update query args to trigger a re-read
-      setStartingIndex((index) => index + BID_COUNT);
-    }
-  }, [bidsQuery.isSuccess]);
+    if (!bidsQuery.isSuccess) return;
+
+    const isBidIdFound =
+      bidsQuery.data.findIndex((b: bigint) => b === bidId) !== -1;
+
+    const noMoreBidsToSearch = startingIndex + BID_COUNT >= numBidsQuery.data!;
+
+    if (isBidIdFound || noMoreBidsToSearch) return;
+
+    // Update query args to trigger a re-read
+    setStartingIndex((index) => index + BID_COUNT);
+  }, [
+    bidId,
+    bidsQuery.data,
+    bidsQuery.isSuccess,
+    numBidsQuery.data,
+    startingIndex,
+  ]);
+
+  const batchIndex =
+    bidId !== undefined && bidsQuery.data ? bidsQuery.data.indexOf(bidId) : -1;
+
+  const index =
+    batchIndex !== -1 ? startingIndex + BigInt(batchIndex) : undefined;
 
   return {
-    index: bidsQuery.data?.findIndex((b: bigint) => b === bidId),
+    index,
     ...bidsQuery,
   };
 }


### PR DESCRIPTION
- refund bid logic was missing the previous indexes that had been searched, returning only the index for the current batch
- increase batch size from 100 to 500 to reduce the number of async calls for large auctions (rpcs handle 500 size int array np)